### PR TITLE
The [files]/include directive should accept unix style glob expressions

### DIFF
--- a/gondor/__main__.py
+++ b/gondor/__main__.py
@@ -206,12 +206,7 @@ def cmd_deploy(args, config):
             "staticfiles": config_value(local_config, "app", "staticfiles"),
             "site_media_url": config_value(local_config, "app", "site_media_url"),
         }
-        include_files = []
-        cwd = os.getcwd()
-        os.chdir(utils.find_nearest(os.getcwd(), ".git"))
-        for x in config_value(local_config, "files", "include", "").split("\n"):
-            include_files += glob.glob(x)
-        os.chdir(cwd)
+        include_expr = config_value(local_config, "files", "include", "").split("\n")
         
         out("[ok]\n")
         
@@ -253,6 +248,13 @@ def cmd_deploy(args, config):
         if check != 0:
             error(output)
         out("[ok]\n")
+        
+        include_files = []
+        cwd = os.getcwd()
+        os.chdir(repo_root)
+        for x in include_expr:
+            include_files += glob.glob(x)
+        os.chdir(cwd)
         
         if include_files:
             out("Adding untracked files... ")


### PR DESCRIPTION
As the title says, the [files]/include directive introduced by #11 should be able to correctly parse glob expressions.

Each path is expanded using the glob.glob function and added to the deployment archive.

**Example:**
All my .css files are generated by SASS and thus not tracked by my vcs. To deploy them, I would be able to configure gondor like this:

```
[files]
include = frontend/static/styles/*.css
```
