### PR TITLE
Adding mercurial subrepository support

### DIFF
--- a/gondor/__main__.py
+++ b/gondor/__main__.py
@@ -242,7 +242,7 @@ def cmd_deploy(args, config):
             except KeyError:
                 error("could not map '%s' to a SHA\n" % commit)
             tar_path = os.path.abspath(os.path.join(repo_root, "%s-%s.tar" % (label, sha)))
-            cmd = ["hg", "archive", "-p", ".", "-t", "tar", "-r", commit, tar_path]
+            cmd = ["hg", "archive", "-S", "-p", ".", "-t", "tar", "-r", commit, tar_path]
         else:
             error("'%s' is not a valid version control system for Gondor\n" % vcs)
         


### PR DESCRIPTION
This enables the flag in the hg archive command that will recurse subrepos if they exist. This enables people to deploy subrepos to their site.

Currently I use this for a common templates subrepo that I share among projects that just covers basic 404 and other error pages, all inheriting from the same base name so the look changes from site to site but the content is the same.

I use mercurial, so github doesn't know about my commit username sadly.
