### PR TITLE
Fix Deploying Mercurial by a Non Branch/Tag

### DIFF
--- a/gondor/__main__.py
+++ b/gondor/__main__.py
@@ -185,7 +185,7 @@ def cmd_deploy(args, env, config):
             if check != 0:
                 error("could not map '%s' to a SHA\n" % commit)
             tar_path = os.path.abspath(os.path.join(env["repo_root"], "%s-%s.tar" % (label, sha)))
-            cmd = [hg, "archive", "-p", ".", "-t", "tar", "-r", sha, tar_path]
+            cmd = [hg, "archive", "-p", ".", "-t", "tar", "-r", commit, tar_path]
         else:
             error("'%s' is not a valid version control system for Gondor\n" % config["gondor.vcs"])
         


### PR DESCRIPTION
Currently git deploys allow you to deploy by any valid identifier for a commit, however Mercurial deploys only allow deploying by branches or tags. This brings the two in line and now Mercurial users will no longer have to tag a commit just to deploy it.

This PR should support

```
# Branches
gondor deploy primary default

# Tags
gondor deploy primary v1.0

# Local Revision Numbers
gondor deploy primary 2

# SHA Hashes
gondor deploy primary f0deb90d5b80
```
