### PR TITLE
SSLv3 protocol version-be-gone

### DIFF
--- a/gondor/__main__.py
+++ b/gondor/__main__.py
@@ -544,7 +544,6 @@ def cmd_run(args, env, config):
                 ssl_kwargs = {
                     "ca_certs": os.path.join(os.path.abspath(os.path.dirname(__file__)), "ssl", "run.gondor.io.crt"),
                     "cert_reqs": ssl.CERT_REQUIRED,
-                    "ssl_version": ssl.PROTOCOL_SSLv3
                 }
                 sock = ssl.wrap_socket(sock, **ssl_kwargs)
                 try:


### PR DESCRIPTION
**This pull request is for the purposes of discussion only. DO NOT MERGE.**

Some context:
- SSLv3 has problems (ref: https://poodle.io/).
- The ssl module in Python appears to have removed SSLv3 support (https://bugs.python.org/issue22638). At the very least, in Python 2.7.9 on Debian Jessie I get the following error:

```
$ gondor run primary manage.py syncdb --noinput
Attaching... Traceback (most recent call last):
  File "/home/ntoll/.virtualenvs/pinax-bootcamp/bin/gondor", line 9, in <module>
    load_entry_point('gondor==1.2.5', 'console_scripts', 'gondor')()
  File "/home/ntoll/.virtualenvs/pinax-bootcamp/local/lib/python2.7/site-packages/gondor/__main__.py", line 1014, in main
    }[args.command](args, env, config)
  File "/home/ntoll/.virtualenvs/pinax-bootcamp/local/lib/python2.7/site-packages/gondor/__main__.py", line 547, in cmd_run
    "ssl_version": ssl.PROTOCOL_SSLv3
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
```
- As you can see from this spike, my initial thought was to remove the explicit specification of an ssl version to use when connecting to gondor.io and let the client script and the gondor.io server do the SSL handshake to work out something sensible themselves.
- Turns out the gondor client just hangs when attempting to do the handshake:

```
$ gondor run primary manage.py syncdb --noinput
Attaching... ^CTraceback (most recent call last):
  File "/home/ntoll/.virtualenvs/pinax-bootcamp/bin/gondor", line 9, in <module>
    load_entry_point('gondor==1.2.5', 'console_scripts', 'gondor')()
  File "/home/ntoll/src/eldarion/gondor-client/gondor/__main__.py", line 1013, in main
    }[args.command](args, env, config)
  File "/home/ntoll/src/eldarion/gondor-client/gondor/__main__.py", line 550, in cmd_run
    sock.connect(endpoint)
  File "/usr/lib/python2.7/ssl.py", line 824, in connect
    self._real_connect(addr, False)
  File "/usr/lib/python2.7/ssl.py", line 815, in _real_connect
    self.do_handshake()
  File "/usr/lib/python2.7/ssl.py", line 788, in do_handshake
    self._sslobj.do_handshake()
KeyboardInterrupt
```
- This leads me to suspect (please confirm) that the server at gondor.io only speaks SSLv3.
- My next question: if this is the case, why..?
- Bonus question: if not, any idea what's going on..? ;-)

I'm happy to act as the crash test dummy for all this. It's blocking me being able to deploy a working copy of my Pinax bootcamp blog (since I can't `syncdb` on gondor.io).

Please feel free to tell me I'm an idiot if I've missed something blindingly obvious here. At the very least, I get to learn something new (a good thing). ;-)
